### PR TITLE
Update DeviceSimulator_RaspPi v2.js

### DIFF
--- a/DeviceSimulator_RaspPi v2.js
+++ b/DeviceSimulator_RaspPi v2.js
@@ -28,6 +28,7 @@ function getMessage(cb) {
       cb(JSON.stringify({
         messageId: messageId,
         deviceId: '110203',
+        measureTimeStamp : new Date(),
         temperature: data.temperature_C,
         tempmin: 15,
         tempmax: 35,


### PR DESCRIPTION
Added measurement datetimestamp to be used in place of the Enqueuedtimestamp